### PR TITLE
Ensure Houkou is used as a constructor

### DIFF
--- a/houkou.js
+++ b/houkou.js
@@ -7,6 +7,9 @@ function merge(a, b) {
 }
 
 function Houkou(pattern) {
+  if (!(this instaceof Houkou) {
+    return new Houkou(pattern);
+  }
   this.parameters = (pattern.match(/:([a-z_]+)/gi) || []).map(function(p) { return p.substr(1); });
   this.pattern = new RegExp(("^" + pattern.replace(/:[a-z_]+?!\(|:[a-z_]+$/gi, "(.+?)").replace(/:[a-z_]+/gi, "") + "$").replace(/\//g, "\\/"));
   this.build = new Function("v", 'return "' + pattern.replace(/:([a-z_]+)(?:\(.*?\))?/gi, '" + v["$1"] + "') + '";');


### PR DESCRIPTION
When the user tries to create a Houkou instance but forgets the "new" operator, "this" inside the Houkou function will refer to the global object (or is undefined in ECMAScript5, that is).

I think adding properties to that (global or undefined) object is not what we want to do :)
